### PR TITLE
prevent placement in adventure mode

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,7 @@ if (System.getenv("MODRINTH_TOKEN")) {
 		loaders = ['quilt', 'fabric']
 		detectLoaders = false
 		dependencies {
-			project 'fabric-api'
+			required.version libs.fapi.get().getName(), libs.versions.fapi.get()
 		}
 		changelog = "Changelog: https://github.com/HestiMae/loggerhead-luminancies/releases/tag/v" + baseVersion
 		syncBodyFrom = rootProject.file("README.md").text

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,6 @@ org.gradle.configureondemand=true
 # Enable advanced multi-module optimizations (share tiny-remaper instance between projects)
 fabric.loom.multiProjectOptimisation=true
 # Mod Properties
-baseVersion = 0.1.0
+baseVersion = 0.1.1
 defaultBranch = main
 branch = 1.20.4

--- a/src/main/java/garden/hestia/loggerhead_luminancies/block/ScuteLanternBlock.java
+++ b/src/main/java/garden/hestia/loggerhead_luminancies/block/ScuteLanternBlock.java
@@ -2,17 +2,14 @@ package garden.hestia.loggerhead_luminancies.block;
 
 import com.mojang.serialization.MapCodec;
 import garden.hestia.loggerhead_luminancies.block.entity.ScuteLanternBlockEntity;
-import net.minecraft.block.BlockRenderType;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.BlockWithEntity;
 import net.minecraft.block.ShapeContext;
 import net.minecraft.block.entity.BlockEntity;
-import net.minecraft.fluid.Fluids;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.shape.VoxelShape;
 import net.minecraft.util.shape.VoxelShapes;
 import net.minecraft.world.BlockView;
-import net.minecraft.world.WorldView;
 import org.jetbrains.annotations.Nullable;
 
 public class ScuteLanternBlock extends BlockWithEntity {
@@ -27,11 +24,6 @@ public class ScuteLanternBlock extends BlockWithEntity {
         return CODEC;
     }
 
-    @Override
-    public BlockRenderType getRenderType(BlockState blockState) {
-        return BlockRenderType.INVISIBLE;
-    }
-
     @Nullable
     @Override
     public BlockEntity createBlockEntity(BlockPos blockPos, BlockState blockState) {
@@ -41,11 +33,5 @@ public class ScuteLanternBlock extends BlockWithEntity {
     @Override
     public VoxelShape getOutlineShape(BlockState blockState, BlockView blockView, BlockPos blockPos, ShapeContext shapeContext) {
         return VoxelShapes.cuboid(0, -0.2, 0, 1, 0.4, 1);
-    }
-
-    @Override
-    public boolean canPlaceAt(BlockState blockState, WorldView worldView, BlockPos blockPos) {
-        BlockPos below = blockPos.down();
-        return worldView.getFluidState(blockPos).getFluid() == Fluids.EMPTY && worldView.getFluidState(below).getFluid() == Fluids.WATER;
     }
 }


### PR DESCRIPTION
accidental double dipping - canPlaceAt was added but didn't work, PlaceableOnWaterItem covers this behaviour. canPlaceAt is used when adventure and spectator modes are on, instead.