### PR TITLE
smooth moves + particles + collision again

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,7 @@ if (System.getenv("MODRINTH_TOKEN")) {
 		loaders = ['quilt', 'fabric']
 		detectLoaders = false
 		dependencies {
-			project 'fabric-api'
+			required.version libs.fapi.get().getName(), libs.versions.fapi.get()
 		}
 		changelog = "Changelog: https://github.com/HestiMae/loggerhead-luminancies/releases/tag/v" + baseVersion
 		syncBodyFrom = rootProject.file("README.md").text

--- a/src/main/java/garden/hestia/loggerhead_luminancies/LoggerheadLuminancies.java
+++ b/src/main/java/garden/hestia/loggerhead_luminancies/LoggerheadLuminancies.java
@@ -22,7 +22,7 @@ import net.minecraft.util.Util;
 public class LoggerheadLuminancies implements ModInitializer {
     private static final String ID = "loggerhead_luminancies";
 
-    public static final Block SCUTE_LANTERN = Registry.register(Registries.BLOCK, LoggerheadLuminancies.id("scute_lantern"), new ScuteLanternBlock(FabricBlockSettings.copyOf(Blocks.SEA_LANTERN).nonOpaque().noCollision()));
+    public static final Block SCUTE_LANTERN = Registry.register(Registries.BLOCK, LoggerheadLuminancies.id("scute_lantern"), new ScuteLanternBlock(FabricBlockSettings.copyOf(Blocks.SEA_LANTERN).nonOpaque()));
     public static final BlockEntityType<ScuteLanternBlockEntity> SCUTE_LANTERN_BLOCK_ENTITY_TYPE = Registry.register(Registries.BLOCK_ENTITY_TYPE, LoggerheadLuminancies.id("scute_lantern"), BlockEntityType.Builder.create(ScuteLanternBlockEntity::new, SCUTE_LANTERN).build(Util.getChoiceType(TypeReferences.BLOCK_ENTITY, "scute_lantern")));
     public static final BlockItem SCUTE_LANTERN_ITEM = Registry.register(Registries.ITEM, LoggerheadLuminancies.id("scute_lantern"), new PlaceableOnWaterItem(SCUTE_LANTERN, new FabricItemSettings()));
     @Override

--- a/src/main/java/garden/hestia/loggerhead_luminancies/block/ScuteLanternBlock.java
+++ b/src/main/java/garden/hestia/loggerhead_luminancies/block/ScuteLanternBlock.java
@@ -7,11 +7,14 @@ import net.minecraft.block.BlockState;
 import net.minecraft.block.BlockWithEntity;
 import net.minecraft.block.ShapeContext;
 import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.block.entity.BlockEntityTicker;
+import net.minecraft.block.entity.BlockEntityType;
 import net.minecraft.fluid.Fluids;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.shape.VoxelShape;
 import net.minecraft.util.shape.VoxelShapes;
 import net.minecraft.world.BlockView;
+import net.minecraft.world.World;
 import net.minecraft.world.WorldView;
 import org.jetbrains.annotations.Nullable;
 
@@ -20,6 +23,12 @@ public class ScuteLanternBlock extends BlockWithEntity {
 
     public ScuteLanternBlock(Settings settings) {
         super(settings);
+    }
+
+    @Nullable
+    @Override
+    public <T extends BlockEntity> BlockEntityTicker<T> getTicker(World world, BlockState blockState, BlockEntityType<T> blockEntityType) {
+        return world.isClient() ? ScuteLanternBlockEntity::clientTick : null;
     }
 
     @Override

--- a/src/main/java/garden/hestia/loggerhead_luminancies/block/entity/ScuteLanternBlockEntity.java
+++ b/src/main/java/garden/hestia/loggerhead_luminancies/block/entity/ScuteLanternBlockEntity.java
@@ -4,10 +4,18 @@ import garden.hestia.loggerhead_luminancies.LoggerheadLuminancies;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
 
 public class ScuteLanternBlockEntity extends BlockEntity {
+    public long timeAlive = 0;
 
-    public ScuteLanternBlockEntity(BlockPos blockPos, BlockState blockState) {
-        super(LoggerheadLuminancies.SCUTE_LANTERN_BLOCK_ENTITY_TYPE, blockPos, blockState);
+    public static <T extends BlockEntity> void clientTick(World world, BlockPos pos, BlockState blockState, T blockEntity) {
+        if (blockEntity instanceof ScuteLanternBlockEntity self) {
+            self.timeAlive++;
+        }
+    }
+
+    public ScuteLanternBlockEntity(BlockPos pos, BlockState state) {
+        super(LoggerheadLuminancies.SCUTE_LANTERN_BLOCK_ENTITY_TYPE, pos, state);
     }
 }

--- a/src/main/java/garden/hestia/loggerhead_luminancies/client/render/ScuteLanternBlockEntityRenderer.java
+++ b/src/main/java/garden/hestia/loggerhead_luminancies/client/render/ScuteLanternBlockEntityRenderer.java
@@ -23,8 +23,7 @@ public class ScuteLanternBlockEntityRenderer implements BlockEntityRenderer<Scut
     }
     @Override
     public void render(ScuteLanternBlockEntity blockEntity, float tickDelta, MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int light, int overlay) {
-        long time = blockEntity.getWorld().getTime();
-        double tick = time + tickDelta;
+        double tick = blockEntity.timeAlive + tickDelta;
         double yOffset = Math.sin(tick/10.0F)/5.0F - 0.4F;
         matrixStack.translate(0, yOffset, 0);
         this.root.render(matrixStack, SCUTE_LANTERN_TEXTURE.getVertexConsumer(vertexConsumerProvider, RenderLayer::getEntitySolid), light, overlay);

--- a/src/main/resources/assets/loggerhead_luminancies/models/block/scute_lantern.json
+++ b/src/main/resources/assets/loggerhead_luminancies/models/block/scute_lantern.json
@@ -1,3 +1,6 @@
 {
-	"parent": "minecraft:block/cube_all"
+	"parent": "minecraft:block/cube_all",
+	"textures": {
+		"particle": "loggerhead_luminancies:block/scute_lantern_right"
+	}
 }


### PR DESCRIPTION
because time is sync'd via packets in smp, keeping a tick count on the client works better instead.

scute lanterns will bob based on when they were loaded/placed:

https://github.com/HestiMae/loggerhead-luminancies/assets/55819817/9be9689f-7f69-4235-b14e-9475d42e464f

